### PR TITLE
Crit dragging removal

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -221,9 +221,11 @@
 	if(L.buckled)
 		return FALSE //to stop xeno from pulling marines on roller beds.
 	if(ishuman(L))
-		if(L.stat == UNCONSCIOUS && !bypass_crit_delay)
-			if(!do_mob(src, L , XENO_PULL_CHARGE_TIME, BUSY_ICON_HOSTILE))
-				return FALSE
+		if(L.health < L.get_crit_threshold() && L.stat != DEAD) //kill them if they're in crit
+			to_chat(usr,"<span class='xenowarning'>We attempt to get a grip on [L], but they appear to die from their critical injuries in the process. How disgusting!</span>")
+			L.death()
+			return FALSE
+				
 		if(L.stat == DEAD) //Can't drag dead human bodies
 			to_chat(usr,"<span class='xenowarning'>This looks gross, better not touch it</span>")
 			return FALSE


### PR DESCRIPTION
## About the Pull Request
Humans in critical condition now die when dragged by a xenomorph.

## Why it's Good for the Game

Removing crit dragging will reduce frustration for both sides. Marines won't have to deal with being dragged to the other end of the map and xenos won't have to deal with pre-drugged marines healing out of crit (amplified by the fact that the vali module can now inject a custom chem mix while in crit).

Crit dragging is a chore for xenos at best and a very scummy experience for marines at worst. There's no reason to keep it in the game while corpse dragging is disabled.

## Changelog
:cl: Chipswithchops
fix: Crit dragging removal. Humans in critical condition now die when dragged by a xenomorph.
\:cl:
